### PR TITLE
Function default values

### DIFF
--- a/examples/os_sys.rs
+++ b/examples/os_sys.rs
@@ -26,7 +26,7 @@ fn main() -> pyo3::PyResult<()> {
         // Get the current working directory via "os" Python module
         let current_dir = os::getcwd(py)?;
         // Get the relative path to the Python executable via "posixpath" Python module
-        let relpath_to_python_exe = posixpath::relpath(py, python_exe_path, current_dir)?;
+        let relpath_to_python_exe = posixpath::relpath(py, python_exe_path, Some(current_dir))?;
 
         println!("Relative path to Python executable: '{relpath_to_python_exe}'");
         Ok(())

--- a/pyo3_bindgen_engine/src/syntax/function.rs
+++ b/pyo3_bindgen_engine/src/syntax/function.rs
@@ -376,15 +376,35 @@ impl Function {
             .iter()
             .zip(param_idents.iter())
             .map(|(param, param_ident)| {
-                param
+                let bind = param
                     .annotation
-                    .preprocess_borrowed(param_ident, local_types)
+                    .preprocess_borrowed(param_ident, local_types);
+
+                if param.default.is_some() {
+                    let option_ident = quote::format_ident!("optional_{}", param_ident);
+                    quote::quote! {
+                        let #option_ident = #param_ident.is_some();
+                        #bind
+                    }
+                } else {
+                    bind
+                }
             })
             .collect();
         let param_types: Vec<proc_macro2::TokenStream> = self
             .parameters
             .iter()
-            .map(|param| Result::Ok(param.annotation.clone().into_rs_borrowed(local_types)))
+            .map(|param| {
+                let local_type = param.annotation.clone().into_rs_borrowed(local_types);
+                let res = if param.default.is_some() {
+                    quote::quote! {
+                        Option<#local_type>
+                    }
+                } else {
+                    local_type
+                };
+                Result::Ok(res)}
+            )
             .collect::<Result<Vec<_>>>()?;
         let return_type = self.return_annotation.clone().into_rs_owned(local_types);
         let fn_contract = match &self.typ {
@@ -568,6 +588,10 @@ impl Function {
             .iter()
             .map(|param| Ok(Ident::from_py(&format!("p_{}", param.name)).try_into()?))
             .collect::<Result<_>>()?;
+        let keyword_args_idents_optional: Vec<syn::Ident> = keyword_args_idents
+            .iter()
+            .map(|param| quote::format_ident!("optional_{}", param))
+            .collect::<_>();
         let var_keyword_args_ident: Option<syn::Ident> = self
             .parameters
             .iter()
@@ -580,11 +604,14 @@ impl Function {
                     #var_keyword_args_ident
                 }
             } else {
+                //let option_ident: syn::Ident = Ident::from_py(&format!("optional_{}", param.name)).try_into().unwrap();
                 quote::quote! {
                     {
                         let __internal__kwargs = #var_keyword_args_ident;
                         #(
-                            ::pyo3::types::PyDictMethods::set_item(&__internal__kwargs, ::pyo3::intern!(py, #keyword_args_names), #keyword_args_idents);
+                            if format_ident!("optional{}", keyword_args_idents) {
+                                ::pyo3::types::PyDictMethods::set_item(&__internal__kwargs, ::pyo3::intern!(py, #keyword_args_names), #keyword_args_idents);
+                            };
                         )*
                         __internal__kwargs
                     }
@@ -599,7 +626,9 @@ impl Function {
                 {
                     let __internal__kwargs = ::pyo3::types::PyDict::new_bound(py);
                     #(
-                        ::pyo3::types::PyDictMethods::set_item(&__internal__kwargs, ::pyo3::intern!(py, #keyword_args_names), #keyword_args_idents);
+                        if #keyword_args_idents_optional {
+                            ::pyo3::types::PyDictMethods::set_item(&__internal__kwargs, ::pyo3::intern!(py, #keyword_args_names), #keyword_args_idents);
+                        };
                     )*
                     __internal__kwargs
                 }


### PR DESCRIPTION
The rust function signature did not allow default values. Instead the user had to know these values to fill them in.

Every paramter, that has a default value, will now be wrapped inside an option. A user can this then set to None.
If this option is None, it will be excluded from the kwargs dict, and thus the default value will be used.

Furthermore, the Optional Value from typing is excluded.

I am not sure if everything was done correctly and every occurence was changed.
There might be edge cases where this will break, however on the tested examples this worked fine.